### PR TITLE
Replace submitStats query with submitStatsGlobal query for accurate results

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -24,7 +24,7 @@ export class Query {
                         country: countryName 
                         ranking
                     }
-                    submits: submitStats {
+                    submits: submitStatsGlobal {
                         ac: acSubmissionNum { difficulty count }
                     }
                 }


### PR DESCRIPTION
https://github.com/JacobLinCool/LeetCode-Stats-Card/issues/96

## Description
Submit stats are incorrect for some specific users. For example with the users with LeetCode usernames `stevenewald` and `infernity25`.

## Changes Made
The LeetCode API seems to expose two queries for retrieving the submit stats: `submitStats` and `submitStatsGlobal` as documented here: https://github.com/search?q=repo%3Aakarsh1995%2Fleetcode-graphql-queries%20submitStats&type=code. 

Replacing the `submitStats` query with `submitStatsGlobal` seems to now be displaying the correct submit stats value for the example above, but also for other usernames that previously also worked. Ideally, a test should be made to test a username that normally doesn't display the correct submit stats if `submitStats` query is used.

## Notes
Personally, I don't know what the difference between these two queries is (other than the difference in results) or why `submitStats` doesn't retrieve the correct count for each question difficulty. And I haven't yet done the research to figure this out.

Edit:
Thanks to Discord user `Infernity25`: "It seems submitStats only pulls from the current session, while subStatsGlobal probably pulls data from ALL sessions. I tried switching my sessions within LC and saw results that corresponded with the session stats."