### PR TITLE
Create transparent theme

### DIFF
--- a/src/core/theme/transparent
+++ b/src/core/theme/transparent
@@ -1,0 +1,10 @@
+import { Theme } from "./_theme";
+
+export default Theme({
+    palette: {
+        bg: ["rgba(16, 16, 16, 0.5)", "rgba(64, 64, 64, 0.5)"],
+        text: ["#f0f0f0", "#dcdcdc"],
+        color: ["#ffa116", "#5cb85c", "#f0ad4e", "#d9534f"],
+    },
+    css: `#L{fill:#fff}`,
+});


### PR DESCRIPTION
bg: Updated to use rgba values for transparency. Adjust the alpha channel (the last value) to control the transparency level.
text and color: Remain unchanged as they don’t need transparency.
css: The CSS rule for #L remains as you specified, which sets the fill color to white.