### PR TITLE
Handle null contest history

### DIFF
--- a/packages/core/src/exts/contest.ts
+++ b/packages/core/src/exts/contest.ts
@@ -10,7 +10,9 @@ export async function ContestExtension(generator: Generator): Promise<Extension>
             lc.user_contest_info(generator.config.username)
                 .then((data) => {
                     try {
-                        const history = data.userContestRankingHistory.filter((x) => x.attended);
+                        const history = Array.isArray(data.userContestRankingHistory)
+                            ? data.userContestRankingHistory.filter((x) => x.attended)
+                            : [];
 
                         if (history.length === 0) {
                             resolve(null);


### PR DESCRIPTION
## Summary
- protect `ContestExtension` when `userContestRankingHistory` is null

## Testing
- `pnpm test` *(fails: request to leetcode.com failed)*